### PR TITLE
Update camelcase-css, fixing mixed-case properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "repository": "postcss/postcss-js",
   "dependencies": {
-    "camelcase-css": "^1.0.1",
+    "camelcase-css": "^2.0.0",
     "postcss": "^6.0.11"
   },
   "devDependencies": {

--- a/test/objectifier.test.js
+++ b/test/objectifier.test.js
@@ -113,3 +113,11 @@ it('converts at-rules without body', () => {
         '@charset "UTF-8"': true
     });
 });
+
+it('handles mixed case properties', () => {
+    var root = parse('COLOR: green; -WEBKIT-border-radius: 6px');
+    expect(postcssJS.objectify(root)).toEqual({
+        color: 'green',
+        WebkitBorderRadius: '6px'
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -406,9 +406,9 @@ callsites@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
 
-camelcase-css@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/camelcase-css/-/camelcase-css-1.0.1.tgz#157c4238265f5cf94a1dffde86446552cbf3f705"
+camelcase-css@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/camelcase-css/-/camelcase-css-2.0.0.tgz#76f0aed4924b9d3dde36adf14225c06d5a9835ae"
 
 camelcase@^1.0.2:
   version "1.2.1"


### PR DESCRIPTION
The latest version of `camelcase-css` fixes the way mixed-case properties are handled. Now properties are properly camelcased whether the source is uppercase or lowercase. (See https://github.com/stevenvachon/camelcase-css/pull/1)

In addition to updating the dependency, I added a test that fails before the update, illustrating the problem.