### PR TITLE
Add failing test for parsing !important

### DIFF
--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -12,6 +12,12 @@ it('parses declarations', function () {
   expect(root.toString()).toEqual('color: black;\nbackground: white')
 })
 
+it('parses declarations with !important', function () {
+  var root = postcssJS.parse({ color: 'black !important', background: 'white' })
+  expect(root.first.important).toBe(true)
+  expect(root.last.important).toBe(undefined)
+})
+
 it('converts camelCase', function () {
   var root = postcssJS.parse({ zIndex: '1' })
   expect(root.toString()).toEqual('z-index: 1')

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -14,6 +14,7 @@ it('parses declarations', function () {
 
 it('parses declarations with !important', function () {
   var root = postcssJS.parse({ color: 'black !important', background: 'white' })
+  expect(root.first.value).toEqual('black')
   expect(root.first.important).toBe(true)
   expect(root.last.important).toBe(undefined)
 })


### PR DESCRIPTION
I'm not sure the best way to fix this or if this is just expected behavior, but I noticed that trying to parse a JS object style that includes `!important` doesn't actually set the `important` property on the declaration node.

What do you think should happen here?