### PR TITLE
Bugfix: CSS variables should not be camel-cased

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,16 @@ postcss().process(style, { parser: postcssJs }).then( (result) => {
 const postcss = require('postcss')
 const postcssJs = require('postcss-js')
 
-const css  = '@media screen { z-index: 1 }'
+const css  = '--text-color: #DD3A0A; @media screen { z-index: 1; color: var(--text-color) }'
 const root = postcss.parse(css);
 
-postcssJs.objectify(root) //=> { '@media screen': { zIndex: '1' } }
+postcssJs.objectify(root) //=> {
+                          //     --text-color: '#DD3A0A',
+                          //     '@media screen': {
+                          //       zIndex: '1',
+                          //       color: 'var(--text-color)'
+                          //     }
+                          //   }
 ```
 
 ## API

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ const css  = '--text-color: #DD3A0A; @media screen { z-index: 1; color: var(--te
 const root = postcss.parse(css);
 
 postcssJs.objectify(root) //=> {
-                          //     --text-color: '#DD3A0A',
+                          //     '--text-color': '#DD3A0A',
                           //     '@media screen': {
                           //       zIndex: '1',
                           //       color: 'var(--text-color)'

--- a/objectifier.js
+++ b/objectifier.js
@@ -10,7 +10,7 @@ function atRule (node) {
 
 function process (node) {
   var name
-  var result = { }
+  var result = {}
 
   node.each(function (child) {
     if (child.type === 'atrule') {
@@ -33,7 +33,7 @@ function process (node) {
         result[child.selector] = body
       }
     } else if (child.type === 'decl') {
-      if (child.prop.startsWith('--')) {
+      if (child.prop[0] === '-' && child.prop[1] === '-') {
         name = child.prop
       } else {
         name = camelcase(child.prop)

--- a/objectifier.js
+++ b/objectifier.js
@@ -33,7 +33,11 @@ function process (node) {
         result[child.selector] = body
       }
     } else if (child.type === 'decl') {
-      name = camelcase(child.prop)
+      if (child.prop.startsWith('--')) {
+        name = child.prop
+      } else {
+        name = camelcase(child.prop)
+      }
       var value = child.value
       if (child.important) value += ' !important'
       if (typeof result[name] === 'undefined') {

--- a/objectifier.js
+++ b/objectifier.js
@@ -10,7 +10,7 @@ function atRule (node) {
 
 function process (node) {
   var name
-  var result = {}
+  var result = { }
 
   node.each(function (child) {
     if (child.type === 'atrule') {

--- a/test/objectifier.test.js
+++ b/test/objectifier.test.js
@@ -93,7 +93,7 @@ it('converts at-rules without params', function () {
 it('converts at-rules without children', function () {
   var root = parse('@media screen { }')
   expect(postcssJS.objectify(root)).toEqual({
-    '@media screen': { }
+    '@media screen': {}
   })
 })
 
@@ -119,5 +119,12 @@ it('handles mixed case properties', function () {
   expect(postcssJS.objectify(root)).toEqual({
     color: 'green',
     WebkitBorderRadius: '6px'
+  })
+})
+
+it('doesn\'t convert css variables', function () {
+  var root = parse('--test-variable: 0;')
+  expect(postcssJS.objectify(root)).toEqual({
+    '--test-variable': '0'
   })
 })

--- a/test/objectifier.test.js
+++ b/test/objectifier.test.js
@@ -93,7 +93,7 @@ it('converts at-rules without params', function () {
 it('converts at-rules without children', function () {
   var root = parse('@media screen { }')
   expect(postcssJS.objectify(root)).toEqual({
-    '@media screen': {}
+    '@media screen': { }
   })
 })
 


### PR DESCRIPTION
This PR prevents CSS variable properties from being camel-cased they are case sensitive and should not be converted.