### PR TITLE
Preserve case of css variables when parsing

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -37,7 +37,10 @@ function dashify (str) {
 function decl (parent, name, value) {
   if (value === false || value === null) return
 
-  name = dashify(name)
+  if (!name.startsWith('--')) {
+    name = dashify(name)
+  }
+
   if (typeof value === 'number') {
     if (value === 0 || UNITLESS[name]) {
       value = value.toString()

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -105,3 +105,14 @@ it('supports PostCSS syntax API', () => {
   let result = postcss().process({ color: 'black' }, { parser: postcssJS })
   expect(result.css).toEqual('color: black')
 })
+
+it('preseves casing for css variables', () => {
+  let root = postcssJS.parse({
+    '--testVariable0': '0',
+    '--test-Variable-1': '1',
+    '--test-variable-2': '2'
+  })
+  expect(root.toString()).toEqual(
+    '--testVariable0: 0;\n--test-Variable-1: 1;\n--test-variable-2: 2'
+  )
+})


### PR DESCRIPTION
Before when parsing `--testVariable0` it would end up as `--test-variable0`. We still want to convert properties to kebab-case in the typical case so we only bail for css custom properties. Additionally, without this you can't round trip CSS though objectify -> parser when CSS variables are being used that have any uppercase characters. 

It's possible that this behavior is relied upon by some css-in-js users in which case should this be turned into a configuration option instead?