### PR TITLE
Preserve case of sass :export-ed variables when objectifying

### DIFF
--- a/objectifier.js
+++ b/objectifier.js
@@ -60,6 +60,8 @@ function process(node) {
     } else if (child.type === 'decl') {
       if (child.prop[0] === '-' && child.prop[1] === '-') {
         name = child.prop
+      } else if (child.parent && child.parent.selector === ':export') {
+        name = child.prop
       } else {
         name = camelcase(child.prop)
       }

--- a/test/objectifier.test.js
+++ b/test/objectifier.test.js
@@ -40,6 +40,21 @@ test('converts declarations to camel case', () => {
   })
 })
 
+test('preserves case for sass exported variables', () => {
+  let root = parse(
+    ':export { caseSensitiveOne: 1px }' +
+      ':export { caseSensitiveTwo: 2px }' +
+      ':export { caseSensitiveThree: 3px }'
+  )
+  equal(postcssJS.objectify(root), {
+    ':export': {
+      caseSensitiveOne: '1px',
+      caseSensitiveTwo: '2px',
+      caseSensitiveThree: '3px'
+    }
+  })
+})
+
 test('maintains !important declarations', () => {
   let root = parse('margin-bottom: 0 !important')
   equal(postcssJS.objectify(root), {


### PR DESCRIPTION
We're currently using a Vite plugin ([vite-plugin-dts](https://github.com/qmhc/)) to generate *.d.ts files from *.module.scss in our project. This tool uses the `objectify()` function internally to generate the class names list before exporting them to type definitions. Unfortunately our ":export { caseSensitiveVariable: 1px }" gets objectified to the following object:

```json
{
  ":export": {
    "casesensitivevariable": "1px"
  }
}
```

I used [patch-package](https://github.com/ds300/patch-package) to run this on our side and it seems to fix the issue.
For me this seems the easiest place to fix this since, I'm pretty sure other tools dependent on this package might also need this issue fixed.