### PR TITLE
feat: add types

### DIFF
--- a/async.d.ts
+++ b/async.d.ts
@@ -1,0 +1,5 @@
+import { async as _async } from './index.js'
+
+declare const async: typeof _async
+
+export = async

--- a/index.d.mts
+++ b/index.d.mts
@@ -3,7 +3,7 @@ export {
   ObjectifyOptions,
   sync,
   async,
-  objectifiy,
+  objectify,
   parse,
   default
 } from './index.js'

--- a/index.d.mts
+++ b/index.d.mts
@@ -1,0 +1,9 @@
+export {
+  CssInJs,
+  ObjectifyOptions,
+  sync,
+  async,
+  objectifiy,
+  parse,
+  default
+} from './index.js'

--- a/index.d.ts
+++ b/index.d.ts
@@ -43,14 +43,14 @@ declare namespace postcssJs {
    * @param root The root to convert
    * @returns CSS-in-JS object
    */
-  function objectifiy(root: Root, options?: ObjectifyOptions): CssInJs
+  function objectify(root: Root, options?: ObjectifyOptions): CssInJs
 
   export {
     CssInJs,
     ObjectifyOptions,
     sync,
     async,
-    objectifiy,
+    objectify,
     parse,
     postcssJs as default
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,59 @@
+// From DefinitelyTyped by Adam Thompson-Sharpe (https://github.com/MysteryBlokHed) with some modifications.
+import { AcceptedPlugin, Root } from 'postcss'
+
+declare namespace postcssJs {
+  /** CSS-in-JS object */
+  type CssInJs = Record<string, any>
+
+  /**
+   * Create a PostCSS processor with a simple API
+   * @param plugins Synchronous plugins to use with PostCSS
+   * @returns A processor function that accepts (idk) and returns a CSS-in-JS object
+   */
+  function sync(
+    plugins?: readonly AcceptedPlugin[]
+  ): (input: CssInJs) => CssInJs
+  function sync(...plugins: AcceptedPlugin[]): (input: CssInJs) => CssInJs
+
+  /**
+   * Create a PostCSS processor with a simple API, allowing asynchronous plugins
+   * @param plugins Plugins to use with PostCSS
+   * @returns A processor function that accepts (idk) and returns a CSS-in-JS object
+   */
+  function async(
+    plugins?: readonly AcceptedPlugin[]
+  ): (input: CssInJs) => Promise<CssInJs>
+  function async(
+    ...plugins: AcceptedPlugin[]
+  ): (input: CssInJs) => Promise<CssInJs>
+
+  /**
+   * Parse a CSS-in-JS object into a PostCSS `Root`
+   * @param obj The CSS-in-JS to parse
+   * @returns A PostCSS `Root`
+   */
+  function parse(obj: CssInJs): Root
+
+  interface ObjectifyOptions {
+    stringifyImportant?: boolean | undefined
+  }
+
+  /**
+   * Convert a PostCSS `Root` into a CSS-in-JS object
+   * @param root The root to convert
+   * @returns CSS-in-JS object
+   */
+  function objectifiy(root: Root, options?: ObjectifyOptions): CssInJs
+
+  export {
+    CssInJs,
+    ObjectifyOptions,
+    sync,
+    async,
+    objectifiy,
+    parse,
+    postcssJs as default
+  }
+}
+
+export = postcssJs

--- a/objectifier.d.ts
+++ b/objectifier.d.ts
@@ -1,5 +1,7 @@
-import { objectifiy } from './index.js'
+import { ObjectifyOptions, objectifiy } from './index.js'
 
-declare const objectifier: typeof objectifiy
+declare namespace objectifier {
+  export { ObjectifyOptions, objectifiy as default }
+}
 
 export = objectifier

--- a/objectifier.d.ts
+++ b/objectifier.d.ts
@@ -1,0 +1,5 @@
+import { objectifiy } from './index.js'
+
+declare const objectifier: typeof objectifiy
+
+export = objectifier

--- a/parser.d.ts
+++ b/parser.d.ts
@@ -1,0 +1,5 @@
+import { parse } from './index.js'
+
+declare const parser: typeof parse
+
+export = parser

--- a/process-result.d.ts
+++ b/process-result.d.ts
@@ -1,0 +1,7 @@
+import { CssInJs } from './index.js'
+import { LazyResult } from 'postcss'
+import NoWorkResult from 'postcss/lib/no-work-result'
+
+declare function processResult(result: LazyResult | NoWorkResult): CssInJs
+
+export = processResult

--- a/sync.d.ts
+++ b/sync.d.ts
@@ -1,0 +1,5 @@
+import { sync as _sync } from './index.js'
+
+declare const sync: typeof _sync
+
+export = sync


### PR DESCRIPTION
Add types for `postcss-js`, so users don't need to install `@types/postcss-js` separately.
